### PR TITLE
Using signatur key and corresponding certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ m4/Makefile.in
 obj/
 src/Makefile.in
 tests/Makefile.in
+.buildconfig

--- a/README
+++ b/README
@@ -1,12 +1,18 @@
 This is a slightly modified versiong of scute.
 
-The usage of the configure switch --enable-sigkey changes the used key to
-OPENPGP.1 (the signature key. This can be used by e.g. LibreOffice to use a
-signing certificate based upon the signature key instead of the authentication
-key.
+This modifies version generates two shared objects.
+
+The standard scute.so uses Key 3 on card (authentication key.
+
+scutesig.so uses the signature key. It can be used with Libreoffice to sign
+documents with a certificate based upon the signature key, or even to sign mail
+with this certificate in thunderbird.
 
 The modifications were made by:
 Dirk Gottschalk <dirk.gottschalk1980@googlemail.com>
+
+Original README below
+=====================
 
 Scute
 =====

--- a/README
+++ b/README
@@ -1,3 +1,13 @@
+This is a slightly modified versiong of scute.
+
+The usage of the configure switch --enable-sigkey changes the used key to
+OPENPGP.1 (the signature key. This can be used by e.g. LibreOffice to use a
+signing certificate based upon the signature key instead of the authentication
+key.
+
+The modifications were made by:
+Dirk Gottschalk <dirk.gottschalk1980@googlemail.com>
+
 Scute
 =====
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#/bin/sh
+./configure --libdir=/usr/lib64/scute-sig --prefix=/ --enable-silent-rules --enable-maintainer-mode
+make

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #/bin/sh
-./configure --libdir=/usr/lib64/scute-sig --prefix=/ --enable-silent-rules --enable-maintainer-mode
+./configure --libdir=/usr/lib64/scute-sig --prefix=/ --enable-silent-rules --enable-sigkey --enable-maintainer-mode
 make

--- a/configure.ac
+++ b/configure.ac
@@ -313,6 +313,14 @@ else
 fi
 AM_CONDITIONAL(HAVE_GPGSM, test "$GPGSM" != "no")
 
+dnl ***************************************************************************
+dnl Enable the usage of signature key instead of athh key
+dnl ***************************************************************************
+AC_ARG_ENABLE([sigkey],
+    AS_HELP_STRING([--enable-sigkey], [Use signature key]))
+
+AS_IF([test "x$enable_sigkey" = "xyes"], [])
+AM_CONDITIONAL([ENABLE_SIGKEY], [test "$enable_sigkey" = "yes"])
 
 dnl Check for GPGSM version requirement.
 GPGSM_VERSION=unknown

--- a/configure.ac
+++ b/configure.ac
@@ -313,12 +313,6 @@ else
 fi
 AM_CONDITIONAL(HAVE_GPGSM, test "$GPGSM" != "no")
 
-dnl ***************************************************************************
-dnl Enable the usage of signature key instead of athh key
-dnl ***************************************************************************
-AC_ARG_ENABLE([sigkey],
-    AS_HELP_STRING([--enable-sigkey], [Use signature key]))
-
 AS_IF([test "x$enable_sigkey" = "xyes"], [])
 AM_CONDITIONAL([ENABLE_SIGKEY], [test "$enable_sigkey" = "yes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,7 @@ AC_INIT([mym4_package],[mym4_version], [https://bugs.gnupg.org])
 #
 LIBSCUTE_LT_CURRENT=0
 LIBSCUTE_LT_AGE=0
-LIBSCUTE_LT_REVISION=3
+LIBSCUTE_LT_REVISION=4
 
 # Version numbers reported by the PKCS #11 module to its users.
 VERSION_MAJOR=1

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -133,3 +133,7 @@ scute_la_LIBADD = $(scute_libadd) \
 scute_la_CPPFLAGS = -I$(srcdir)/../include \
 	@LIBASSUAN_CFLAGS@ @GPG_ERROR_CFLAGS@
 scute_la_SOURCES = $(sources)
+
+if ENABLE_SIGKEY
+scute_la_CPPFLAGS += -DSIGKEY
+endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,6 +60,35 @@ sources = cryptoki.h pkcs11.h debug.c debug.h settings.h support.h	\
 	p11-verifyrecover.c p11-verifyrecoverinit.c p11-verifyupdate.c	\
 	p11-waitforslotevent.c p11-wrapkey.c sexp-parse.h
 
+sigsources = cryptoki.h pkcs11.h debug.c debug.h settings.h support.h	\
+	locking.h locking.c error-mapping.h error-mapping.c		\
+	get-path.c agent.h agent.c					\
+	slots.h slots-sig.c table.h table.c				\
+	cert.h cert-gpgsm.c cert-object.c gpgsm.h gpgsm.c		\
+	p11-cancelfunction.c p11-closeallsessions.c p11-closesession.c	\
+	p11-copyobject.c p11-createobject.c p11-decrypt.c		\
+	p11-decryptdigestupdate.c p11-decryptfinal.c p11-decryptinit.c	\
+	p11-decryptupdate.c p11-decryptverifyupdate.c p11-derivekey.c	\
+	p11-destroyobject.c p11-digest.c p11-digestencryptupdate.c	\
+	p11-digestfinal.c p11-digestinit.c p11-digestkey.c		\
+	p11-digestupdate.c p11-encrypt.c p11-encryptfinal.c		\
+	p11-encryptinit.c p11-encryptupdate.c p11-finalize.c		\
+	p11-findobjects.c p11-findobjectsfinal.c p11-findobjectsinit.c	\
+	p11-generatekey.c p11-generatekeypair.c p11-generaterandom.c	\
+	p11-getattributevalue.c p11-getfunctionlist.c			\
+	p11-getfunctionstatus.c p11-getinfo.c p11-getmechanisminfo.c	\
+	p11-getmechanismlist.c p11-getobjectsize.c			\
+	p11-getoperationstate.c p11-getsessioninfo.c p11-getslotinfo.c	\
+	p11-getslotlist.c p11-gettokeninfo.c p11-initialize.c		\
+	p11-initpin.c p11-inittoken.c p11-login.c p11-logout.c		\
+	p11-opensession.c p11-seedrandom.c p11-setattributevalue.c	\
+	p11-setoperationstate.c p11-setpin.c p11-sign.c			\
+	p11-signencryptupdate.c p11-signfinal.c	p11-signinit.c		\
+	p11-signrecover.c p11-signrecoverinit.c	p11-signupdate.c	\
+	p11-unwrapkey.c p11-verify.c p11-verifyfinal.c p11-verifyinit.c	\
+	p11-verifyrecover.c p11-verifyrecoverinit.c p11-verifyupdate.c	\
+	p11-waitforslotevent.c p11-wrapkey.c sexp-parse.h
+
 
 if HAVE_LD_VERSION_SCRIPT
 scute_version_script_cmd = -Wl,--version-script=$(srcdir)/libscute.vers
@@ -68,7 +97,8 @@ scute_version_script_cmd =
 endif
 
 
-lib_LTLIBRARIES = scute.la
+lib_LTLIBRARIES = scute.la scutesig.la
+
 
 if HAVE_W32_SYSTEM
 
@@ -134,6 +164,18 @@ scute_la_CPPFLAGS = -I$(srcdir)/../include \
 	@LIBASSUAN_CFLAGS@ @GPG_ERROR_CFLAGS@
 scute_la_SOURCES = $(sources)
 
-if ENABLE_SIGKEY
-scute_la_CPPFLAGS += -DSIGKEY
-endif
+
+scutesig_la_LDFLAGS = $(scute_res_ldflag) $(no_undefined) -module -avoid-version $(export_symbols) \
+	$(scute_version_script_cmd) -version-info \
+	@LIBSCUTE_LT_CURRENT@:@LIBSCUTE_LT_REVISION@:@LIBSCUTE_LT_AGE@
+scutesig_la_DEPENDENCIES = @LTLIBOBJS@ $(srcdir)/libscute.vers $(scute_deps)
+# scute_libadd must come BEFORE libassuan and gpg-error, because we
+# override it on Windows targets.
+scutesig_la_LIBADD = $(scute_libadd) \
+	@LTLIBOBJS@ @LIBASSUAN_LIBS@ @GPG_ERROR_LIBS@
+
+scutesig_la_CPPFLAGS = -I$(srcdir)/../include \
+	@LIBASSUAN_CFLAGS@ @GPG_ERROR_CFLAGS@
+scutesig_la_SOURCES = $(sigsources)
+
+scutesig_la_CPPFLAGS += -DSIGKEY

--- a/src/slots-sig.c
+++ b/src/slots-sig.c
@@ -385,7 +385,7 @@ slot_init (slot_iterator_t id)
   gpg_error_t err = 0;
   struct slot *slot = scute_table_data (slots, id);
 
-  err = scute_gpgsm_get_cert (slot->info.grip3, 3, add_object, slot);
+  err = scute_gpgsm_get_cert (slot->info.grip1, 1, add_object, slot);
 
   if (err)
     goto init_out;
@@ -1034,7 +1034,7 @@ session_sign (slot_iterator_t id, session_iterator_t sid,
     }
 
   sig_len = *pulSignatureLen;
-  err = scute_agent_sign (slot->info.grip3, pData, ulDataLen,
+  err = scute_agent_sign (slot->info.grip1, pData, ulDataLen,
 			  pSignature, &sig_len);
 
   /* FIXME: Oh well.  */

--- a/src/slots.c
+++ b/src/slots.c
@@ -385,7 +385,7 @@ slot_init (slot_iterator_t id)
   gpg_error_t err = 0;
   struct slot *slot = scute_table_data (slots, id);
 
-  err = scute_gpgsm_get_cert (slot->info.grip3, 3, add_object, slot);
+  err = scute_gpgsm_get_cert (slot->info.grip1, 1, add_object, slot);
   if (err)
     goto init_out;
 

--- a/src/slots.c
+++ b/src/slots.c
@@ -385,7 +385,12 @@ slot_init (slot_iterator_t id)
   gpg_error_t err = 0;
   struct slot *slot = scute_table_data (slots, id);
 
+#if SIGKEY
   err = scute_gpgsm_get_cert (slot->info.grip1, 1, add_object, slot);
+#else
+  err = scute_gpgsm_get_cert (slot->info.grip3, 3, add_object, slot);
+#endif
+
   if (err)
     goto init_out;
 
@@ -1033,8 +1038,14 @@ session_sign (slot_iterator_t id, session_iterator_t sid,
     }
 
   sig_len = *pulSignatureLen;
+#if SIGKEY
+  err = scute_agent_sign (slot->info.grip1, pData, ulDataLen,
+			  pSignature, &sig_len);
+#else
   err = scute_agent_sign (slot->info.grip3, pData, ulDataLen,
 			  pSignature, &sig_len);
+#endif
+
   /* FIXME: Oh well.  */
   if (gpg_err_code (err) == GPG_ERR_INV_ARG)
     return CKR_BUFFER_TOO_SMALL;


### PR DESCRIPTION
I modified scute to build a second shared oject called scutesig.so.

This uses the OPENPGP.1 key from the card.

I needed this change to use my signature certigicate, generated with my signature key, to work in Libreoffice and Thunderbird.

If this is of interest for wou, you are welcome to merge this small change info your source tree.
